### PR TITLE
removing renderSpecs

### DIFF
--- a/giftcard.py
+++ b/giftcard.py
@@ -24,13 +24,6 @@ def generate_giftcard_class(issuer_id, class_id):
       'issuerData': {
           'kind': 'walletobjects#typedValue'
       },
-      'renderSpecs': [{
-          'viewName': 'g_list',
-          'templateFamily': '1.giftCard1_list'
-          },{
-          'viewName': 'g_expanded',
-          'templateFamily': '1.giftCard1_expanded'
-      }],
       'programLogo': {
           'kind': 'walletobjects#image',
           'sourceUri': {

--- a/loyalty.py
+++ b/loyalty.py
@@ -96,13 +96,6 @@ def generate_loyalty_class(issuer_id, class_id):
           }
       },
       'programName': 'Baconrista Rewards',
-      'renderSpecs': [{
-          'templateFamily': '1.loyalty_list',
-          'viewName': 'g_list'
-          }, {
-          'templateFamily': '1.loyalty_expanded',
-          'viewName': 'g_expanded'
-      }],
       'rewardsTier': 'Gold',
       'rewardsTierLabel': 'Tier',
       'reviewStatus': 'underReview'

--- a/offer.py
+++ b/offer.py
@@ -22,13 +22,6 @@ def generate_offer_class(issuer_id, class_id):
       'issuerData': {
           'kind': 'walletobjects#typedValue'
       },
-      'renderSpecs': [{
-          'viewName': 'g_list',
-          'templateFamily': '1.offer_list'
-          },{
-          'viewName': 'g_expanded',
-          'templateFamily': '1.offer_expanded'
-      }],
       'title': '20% off one bacon fat latte',
       'redemptionChannel': 'both',
       'provider': 'Baconrista Deals',


### PR DESCRIPTION
renderSpecs was removed completely from the S2AP API, so removing them from the example classes as well.